### PR TITLE
Added language-specific options back into proto files

### DIFF
--- a/model/eic/eic.proto
+++ b/model/eic/eic.proto
@@ -1,5 +1,8 @@
 syntax = "proto2";
 package proio.model.eic;
+option go_package = "eic";
+option java_package = "proio.model";
+option java_outer_classname = "Eic";
 
 ////// TRUTH LEVEL DATA MODEL MESSAGES //////
 

--- a/model/lcio/lcio.proto
+++ b/model/lcio/lcio.proto
@@ -1,5 +1,8 @@
 syntax = "proto3";
 package proio.model.lcio;
+option go_package = "lcio";
+option java_package = "proio.model";
+option java_outer_classname = "Lcio";
 
 message IntParams {
 	repeated int32 array = 1;

--- a/model/mc/mc.proto
+++ b/model/mc/mc.proto
@@ -1,5 +1,8 @@
 syntax = "proto2";
 package proio.model.mc;
+option go_package = "mc";
+option java_package = "proio.model";
+option java_outer_classname = "Mc";
 
 message Particle {
     // ProIO entry identifiers that point to parent Particles

--- a/proio.proto
+++ b/proio.proto
@@ -1,5 +1,8 @@
 syntax = "proto3";
 package proio.proto;
+option go_package = "proto";
+option java_package = "proio";
+option java_outer_classname = "Proto";
 
 // Warning: do not change any fields without understanding how the changes
 // affect the proio libraries.  Any field may be added without affecting the


### PR DESCRIPTION
The justification for this is that it this is still language agnostic, it just adds information relating the package path to language-specific concepts

The real reason for this is so that we can use the maven protobuf compiler plugin without a huge headache